### PR TITLE
Json response

### DIFF
--- a/lowmaf/lowmaf_calc.py
+++ b/lowmaf/lowmaf_calc.py
@@ -44,13 +44,30 @@ def overall_correction(df):
 # calculates a mean of corrections observed for each entry
 # maf_voltages imported from ./models/maf_voltages.py
 def match_maf(df):
-    for i in range (0, len(maf_voltages)-1):
-        vals = df[(df["mass_airflow_voltage"] > maf_voltages[i][0]) & (df["mass_airflow_voltage"] < maf_voltages[i+1][0])]
+    # we go from index = 0 to index = len -1 in the loop because we need a special case for the first and last indicies
+    # check length once for optimization (although compiler might do this)
+    maf_voltages_length = len(maf_voltages) - 1
+    # for index 0, we check values >=0 and <.94
+    # this is due to the way that ECUflash handles interpolation
+    vals = df[(df["mass_airflow_voltage"] >= 0) & (df["mass_airflow_voltage"] < maf_voltages[0]["MafVoltage"])]
+    if (len(vals) > 0):
         mean = vals["correction"].mean()
         mean = np.around(mean, decimals=5)
-        if (np.isnan(mean)):
-            mean = 0
-        maf_voltages[i].append(mean)
+        maf_voltages[0]["Correction"] = mean
+    for i in range (1, maf_voltages_length):
+        vals = df[(df["mass_airflow_voltage"] >= maf_voltages[i]["MafVoltage"]) & (df["mass_airflow_voltage"] < maf_voltages[i+1]["MafVoltage"])]
+        if (len(vals) > 0):
+            mean = vals["correction"].mean()
+            mean = np.around(mean, decimals=5)
+            maf_voltages[i]["Correction"] = mean
+    # special case for last index
+    # we check values >4.69 and <= 5.0
+    vals = df[(df["mass_airflow_voltage"] > maf_voltages[len(maf_voltages)-1]["MafVoltage"]) & (df["mass_airflow_voltage"] <= 5.0)]
+    if (len(vals) > 0):
+        mean = vals["correction"].mean()
+        mean = np.around(mean, decimals=5)
+        maf_voltages[maf_voltages_length]["Correction"] = mean
+
     return maf_voltages
 
 def main(data: list[lowmaf_input]):

--- a/lowmaf/lowmaf_calc.py
+++ b/lowmaf/lowmaf_calc.py
@@ -50,23 +50,29 @@ def match_maf(df):
     # for index 0, we check values >=0 and <.94
     # this is due to the way that ECUflash handles interpolation
     vals = df[(df["mass_airflow_voltage"] >= 0) & (df["mass_airflow_voltage"] < maf_voltages[0]["MafVoltage"])]
-    if (len(vals) > 0):
+    freq = len(vals)
+    if (freq > 0):
         mean = vals["correction"].mean()
         mean = np.around(mean, decimals=5)
         maf_voltages[0]["Correction"] = mean
+        maf_voltages[0]["Frequency"] += freq
     for i in range (1, maf_voltages_length):
         vals = df[(df["mass_airflow_voltage"] >= maf_voltages[i]["MafVoltage"]) & (df["mass_airflow_voltage"] < maf_voltages[i+1]["MafVoltage"])]
-        if (len(vals) > 0):
+        freq = len(vals)
+        if (freq > 0):
             mean = vals["correction"].mean()
             mean = np.around(mean, decimals=5)
             maf_voltages[i]["Correction"] = mean
+            maf_voltages[i]["Frequency"] += freq
     # special case for last index
     # we check values >4.69 and <= 5.0
     vals = df[(df["mass_airflow_voltage"] > maf_voltages[len(maf_voltages)-1]["MafVoltage"]) & (df["mass_airflow_voltage"] <= 5.0)]
+    freq = len(vals)
     if (len(vals) > 0):
         mean = vals["correction"].mean()
         mean = np.around(mean, decimals=5)
         maf_voltages[maf_voltages_length]["Correction"] = mean
+        maf_voltages[maf_voltages_length]["Frequency"] += freq
 
     return maf_voltages
 

--- a/lowmaf/lowmaf_calc.py
+++ b/lowmaf/lowmaf_calc.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 sys.path.append("./models")
-from lowmaf_model import lowmaf_data
+from lowmaf_request_model import lowmaf_input
 from maf_voltages import maf_voltages
 
 # step 1
@@ -53,7 +53,7 @@ def match_maf(df):
         maf_voltages[i].append(mean)
     return maf_voltages
 
-def main(data):
+def main(data: list[lowmaf_input]):
     df = pd.DataFrame([item.dict() for item in data])
     df = dmafdt(df)
     df = outlier_filter(df, 55)

--- a/lowmaf/models/lowmaf_request_model.py
+++ b/lowmaf/models/lowmaf_request_model.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel
 #   We can reuse this api for multiple purposes by filtering for only the fields that we need
 #   This also can potentially provide a security benefit by filtering before transport of data, to prevent sensitive info disclosure
 
-
 class lowmaf_input(BaseModel):
     time: int 
     af_correction_short: float
@@ -19,6 +18,6 @@ class lowmaf_input(BaseModel):
     cl_ol_status: int
 
 class lowmaf_output(BaseModel):
-    MafVoltage: float,
-    Correction: float,
+    MafVoltage: float
+    Correction: float
     Frequency: int

--- a/lowmaf/models/lowmaf_request_model.py
+++ b/lowmaf/models/lowmaf_request_model.py
@@ -1,5 +1,15 @@
 from pydantic import BaseModel
 
+# FastAPI request and response models provide a lot of utility and benefits
+# For this project, some benefits to note:
+# 1. Type Checking: Pydantic models will make sure any api data conforms to the right type
+# 2. Explicitly defined input/output: makes the code more readable
+# 3. Filtering: security and reusability
+#   Lets say we have a main api endpoint that returns 10 fields of data
+#   We can reuse this api for multiple purposes by filtering for only the fields that we need
+#   This also can potentially provide a security benefit by filtering before transport of data, to prevent sensitive info disclosure
+
+
 class lowmaf_input(BaseModel):
     time: int 
     af_correction_short: float
@@ -7,3 +17,8 @@ class lowmaf_input(BaseModel):
     intake_air_temp: int
     mass_airflow_voltage: float
     cl_ol_status: int
+
+class lowmaf_output(BaseModel):
+    MafVoltage: float,
+    Correction: float,
+    Frequency: int

--- a/lowmaf/models/lowmaf_request_model.py
+++ b/lowmaf/models/lowmaf_request_model.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-class lowmaf_data(BaseModel):
+class lowmaf_input(BaseModel):
     time: int 
     af_correction_short: float
     af_correction_learning: float

--- a/lowmaf/models/maf_voltages.py
+++ b/lowmaf/models/maf_voltages.py
@@ -1,35 +1,244 @@
+# list of dictionaries
+# makes it easier to create a json response
 maf_voltages = [
-                    [0.00],
-                    [0.94],
-                    [0.98],
-                    [1.02],
-                    [1.05],
-                    [1.09],
-                    [1.13],
-                    [1.17],
-                    [1.21],
-                    [1.25],
-                    [1.29],
-                    [1.33],
-                    [1.37],
-                    [1.41],
-                    [1.48],
-                    [1.56],
-                    [1.64],
-                    [1.72],
-                    [1.80],
-                    [1.87],
-                    [1.95],
-                    [2.03],
-                    [2.11],
-                    [2.19],
-                    [2.27],
-                    [2.34],
-                    [2.42],
-                    [2.54],
-                    [2.66],
-                    [2.77],
-                    [2.89],
-                    [3.01],
-                    [3.12]
-                ]
+    {
+        "MafVoltage": 0.94,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 0.98,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.02,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.05,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.09,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.13,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.17,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.21,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.25,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.29,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.33,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.37,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.41,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.48,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.56,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.64,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.72,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.80,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.87,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 1.95,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.03,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.11,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.19,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.27,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.34,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.42,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.54,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.66,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.77,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 2.89,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.01,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.12,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.24,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.36,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.48,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.59,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.71,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.83,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 3.95,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.06,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.18,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.30,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.41,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.49,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.57,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.61,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.65,
+        "Correction": 0.00,
+        "Frequency": 0
+    },
+    {
+        "MafVoltage": 4.69,
+        "Correction": 0.00,
+        "Frequency": 0
+    }
+]

--- a/main.py
+++ b/main.py
@@ -1,13 +1,10 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from typing import List
-import pandas as pd
-import numpy as np
 import sys
 
 sys.path.append("lowmaf/models/")
 sys.path.append("lowmaf/")
-from lowmaf_model import lowmaf_data 
+from lowmaf_request_model import lowmaf_input
 import lowmaf_calc
 
 app = FastAPI()
@@ -24,7 +21,7 @@ app.add_middleware(
 
 #lowmaf route
 @app.post("/api/analyze/0/")
-def read_data( log: List[lowmaf_data] ):
+def read_data( log: list[lowmaf_input] ):
     print("Received data that fits into model.")
     resp = lowmaf_calc.main(log)
     print("Calculations completed. Responding with scaling data.")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import sys
 
 sys.path.append("lowmaf/models/")
 sys.path.append("lowmaf/")
-from lowmaf_request_model import lowmaf_input
+from lowmaf_request_model import lowmaf_input, lowmaf_output
 import lowmaf_calc
 
 app = FastAPI()
@@ -20,7 +20,7 @@ app.add_middleware(
 )
 
 #lowmaf route
-@app.post("/api/analyze/0/")
+@app.post("/api/analyze/0/", response_model = list[lowmaf_output])
 def read_data( log: list[lowmaf_input] ):
     print("Received data that fits into model.")
     resp = lowmaf_calc.main(log)


### PR DESCRIPTION
# Accomplishments:
* Insead of the lowmaf response being in the list of lists format, it is now json as:

```json
[
{
"MafVoltage": float,
"Correction": float,
"Frequency": int
},
...
]
```

This makes the response easier to understand and provides additional functionality. it is also easily scaleable

* The maf voltages have been extended for 0v - 5v. Any voltages outside this range are ignored, since it is literally impossible. All turbo subaru ej engines have a maf sensor that reads from 0v - 5v. 
The 0v-.94v range and 4.69-5v are handles as special cases, which are handled accordingly

* Frequency returns the number of data points for each mafvoltage entry. this is useful for tuning

* For security, and code readability purposes I have added fastapi response models for the api response, just like for the api request. this is best practice and I have outlined the benefits in the comments of 
```sh 
./models/lowmaf_request_model.py 
```

* I have also added more comments in the code for readability

# Testing 
I tested using a maf scaling log about 3MB in size with a response time of ~4s